### PR TITLE
교정 전송 오류 및 사진 올리면 바로 보이게 수정

### DIFF
--- a/app/controllers/working_articles_controller.rb
+++ b/app/controllers/working_articles_controller.rb
@@ -193,6 +193,8 @@ class WorkingArticlesController < ApplicationController
          end
        end
      end
+     @image.working_article.generate_pdf_with_time_stamp
+     @image.working_article.page.generate_pdf_with_time_stamp
     redirect_to @working_article
     # images_issue_path(Issue.last.id)
   end

--- a/app/controllers/working_articles_controller.rb
+++ b/app/controllers/working_articles_controller.rb
@@ -193,8 +193,8 @@ class WorkingArticlesController < ApplicationController
          end
        end
      end
-     @image.working_article.generate_pdf_with_time_stamp
-     @image.working_article.page.generate_pdf_with_time_stamp
+    @image.working_article.generate_pdf_with_time_stamp
+    @image.working_article.page.generate_pdf_with_time_stamp
     redirect_to @working_article
     # images_issue_path(Issue.last.id)
   end
@@ -207,6 +207,8 @@ class WorkingArticlesController < ApplicationController
          end
        end
      end
+    @graphic.working_article.generate_pdf_with_time_stamp
+    @graphic.working_article.page.generate_pdf_with_time_stamp
     redirect_to @working_article
   end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -730,9 +730,9 @@ class Page < ApplicationRecord
   def generate_proof_pdf
     FileUtils.mkdir_p(proof_path) unless File.exist?(proof_path)
     r_page_number = page_number.to_s.rjust(2,"0")
-    date          = date.day.to_s.rjust(2,"0")
-    month         = date.month.to_s.rjust(2,"0")
-    year          = date.year.to_s
+    date          = issue.date.day.to_s.rjust(2,"0")
+    month         = issue.date.month.to_s.rjust(2,"0")
+    year          = issue.date.year.to_s
     proof_files   = Dir.glob("#{proof_path}/#{r_page_number}011001*")
     if proof_files.length == 0
       target_file   = "proof/#{r_page_number}011001-#{date}#{month}#{year}000.pdf"

--- a/public/1/text_style/text_style.yml
+++ b/public/1/text_style/text_style.yml
@@ -263,9 +263,9 @@ title_main:
   tracking: -1.0
   space_width: 10.0
   scale: 100.0
-  text_line_spacing:
-  space_before_in_lines: 1
-  space_after_in_lines: 0
+  text_line_spacing: 0
+  space_before_in_lines: 0.5
+  space_after_in_lines: 0.5
   text_height_in_lines: 3
   box_attributes: ''
   markup: ''


### PR DESCRIPTION
- 교정 전송시 이슈 날짜 오류로 전송되지 않던 문제 수정
- 사진/그래픽 올리기 버튼 누르면 페이지 재생성 해서 저장 버튼 누르지 않아도 바로 보이게 수정  